### PR TITLE
feat: introduce atlantis_projects to configure tf modules

### DIFF
--- a/atlantis.tf
+++ b/atlantis.tf
@@ -8,6 +8,10 @@ locals {
     events = ["issue_comment", "pull_request"]
     secret = var.atlantis_webhook_secret
   }
+  atlantis_default_project = {
+    name      = "main"
+    directory = "."
+  }
 }
 
 module "initial_atlantis_commit" {
@@ -28,6 +32,7 @@ module "initial_atlantis_commit" {
       target = "atlantis.yaml"
       data = {
         workspaces = local.atlantis_workspaces
+        projects   = length(var.atlantis_projects) < 1 ? [local.atlantis_default_project] : var.atlantis_projects
       }
     }
   }

--- a/templates/atlantis.yaml
+++ b/templates/atlantis.yaml
@@ -1,11 +1,13 @@
 version: 3
 projects:
 %{ for workspace in workspaces ~}
-- dir: .
-  name: main
+%{ for project in projects ~}
+- dir: ${project.directory}
+  name: ${project.name}
   workflow: ${workspace.workflow}
   workspace: ${workspace.name}
   autoplan:
-    when_modified: ["*.tf", "*.tf*"]
+    when_modified: ["${project.directory}/*.tf", "${project.directory}/*.tf*"]
     enabled: ${workspace.autoplan}
+%{ endfor ~}
 %{ endfor ~}

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,15 @@ variable "atlantis_workspaces" {
   description = "Specifies workspaces to deploy the modules into. Defaults to default name and workflow with autoplan true"
 }
 
+variable "atlantis_projects" {
+  type = list(object({
+    name      = string
+    directory = string
+  }))
+  default     = []
+  description = "Projects to include for the given workspaces. Defaults to project called main within current directory"
+}
+
 variable "atlantis_domain" {
   type        = string
   default     = ""


### PR DESCRIPTION
this might be useful to setup different projects and use different state files for multiple subdirectories/modules. use this with caution as projects may be added to the repository itself over time