### PR TITLE
fix: unshallow clone and fetch history

### DIFF
--- a/templates/actions/helm/lint.yaml
+++ b/templates/actions/helm/lint.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@master
+      - name: Fetch history
+        run: git fetch --prune --unshallow
       - name: Helm Lint
         uses: helm/chart-testing-action@v1.0.0-rc.2
         with:


### PR DESCRIPTION
fails currently on non master branches